### PR TITLE
update ply_io and filter_branch.py

### DIFF
--- a/python/filter_branch.py
+++ b/python/filter_branch.py
@@ -3,7 +3,8 @@ import pandas as pd
 from sklearn.neighbors import NearestNeighbors
 import argparse
 import os
-import qrdar
+import ply_io
+
 
 def nn(df, N=2):
     
@@ -22,6 +23,9 @@ def process_branch(B, length=.01):
     # filter high deviation points
     if 'dev' in B.columns:
         B = B[B.dev.between(0, 10)] 
+    # filter low reflectance points 
+    if 'refl' in B.columns:
+        B = B[B.refl.between(-20,5)]
     
     # fuzz filter
     # voxelise branches (length = 1 cm)
@@ -57,9 +61,10 @@ if __name__ == '__main__':
     parser.add_argument('--suffix', default='', help='file name suffix')
     args = parser.parse_args()
     
-    pc = qrdar.io.read_ply(args.pc)
+    # pc = qrdar.io.read_ply(args.pc)
+    pc = ply_io.read_ply(args.pc)
     b = process_branch(pc)
-    qrdar.io.write_ply(os.path.join(args.odir, '{}{}.ply'.format(os.path.split(args.pc)[1][:-4], 
+    ply_io.write_ply(os.path.join(args.odir, '{}{}.ply'.format(os.path.split(args.pc)[1][:-4], 
                                                                '' if len(args.suffix) == 0 else '.' + args.suffix)), 
                      b)
     

--- a/python/ply_io.py
+++ b/python/ply_io.py
@@ -29,15 +29,22 @@ def read_ply(fp, newline=None):
             if 'element face' in line:
                 raise Exception('.ply appears to be a mesh')
             if 'end_header' in line: break
-    
+
+        for j in range(len(prop)):
+            if 'scalar_' in prop[j]:
+                prop[j] = prop[j].split('scalar_')[-1]
+        
         ply.seek(length)
 
         if fmt == 'binary':
             arr = np.fromfile(ply, dtype=','.join(dtype))
+            df = pd.DataFrame(data=arr)
+            df.columns = prop
+            df = df.dropna()  # drop rows with NAN values
         else:
-            arr = np.loadtxt(ply)
-        df = pd.DataFrame(data=arr)
-        df.columns = prop
+            columns = prop
+            df = pd.read_csv(ply, sep='\s+', names=columns, header=None)
+            df = df.dropna()  # drop rows with NAN values
 
     return df
 

--- a/wx_test/wx_test.ipynb
+++ b/wx_test/wx_test.ipynb
@@ -1,0 +1,503 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## extract selected points and combine scans "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import glob\n",
+    "import pandas as pd\n",
+    "import ply_io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "processing project: \n",
+      "\tprocessing scan position: 1\n",
+      "\tprocessing scan position: 2\n",
+      "\tprocessing scan position: 3\n",
+      "\tprocessing scan position: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "project = '2021-06-28.Ove_W2-Fc(new).riproject/'\n",
+    "name = os.path.split(project)[1]\n",
+    "print ('processing project:', name)\n",
+    "\n",
+    "df = pd.DataFrame()\n",
+    "\n",
+    "for asc in glob.glob(os.path.join(project, 'ascii', '*.ascii')):\n",
+    "\n",
+    "    scan_position = int(os.path.split(asc)[-1][7:10])\n",
+    "    print ('\\tprocessing scan position:', scan_position)\n",
+    "\n",
+    "    # read in scan\n",
+    "    tmp = pd.read_csv(asc, engine='c', dtype=float, error_bad_lines=False)\n",
+    "    tmp.columns = ['PID[]','XYZ[0][m]','XYZ[1][m]','XYZ[2][m]','Deviation[]','Reflectance[dB]','Selected[]']\n",
+    "    column2column = {u'PID[]':'pid', u'Target Count[]':'tot_rtn', u'XYZ[0][m]':'x', u'XYZ[1][m]':'y', u'XYZ[2][m]':'z',\n",
+    "                     u'Deviation[]':'dev', u'Reflectance[dB]':'refl', u'Target Index[]':'rtn_N', u'Selected[]':'sel'}\n",
+    "    tmp.columns = tmp.columns.map(column2column)\n",
+    "    tmp = tmp[tmp.sel == 1]\n",
+    "    if len(tmp) == 0:\n",
+    "        raise Exception('len df == 0, were required points selected in RiSCAN')\n",
+    "    tmp.loc[:, 'sp'] = scan_position\n",
+    "\n",
+    "    # calc distance\n",
+    "    #         mat = np.loadtxt('../matrix/ScanPos00{}.DAT'.format(scan_position))\n",
+    "    #         tmp.loc[:, 'rng'] = np.linalg.norm(tmp[['x', 'y', 'z']] - mat[:3, 3], axis=1)\n",
+    "\n",
+    "    df = df.append(tmp)#[tmp.refl.between(-20, 10)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ply_io.write_ply(os.path.join(project, 'ascii',  name + '.ply'),  \n",
+    "                 df[[c for c in df.columns if isinstance(c, str)]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pid</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>dev</th>\n",
+       "      <th>refl</th>\n",
+       "      <th>sel</th>\n",
+       "      <th>sp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4532169</th>\n",
+       "      <td>9880406.0</td>\n",
+       "      <td>-0.26751</td>\n",
+       "      <td>-1.06231</td>\n",
+       "      <td>-0.99242</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>-4.64</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4532171</th>\n",
+       "      <td>9889137.0</td>\n",
+       "      <td>-0.26801</td>\n",
+       "      <td>-1.06406</td>\n",
+       "      <td>-0.99267</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>-4.38</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4533244</th>\n",
+       "      <td>10050538.0</td>\n",
+       "      <td>-0.29222</td>\n",
+       "      <td>-1.08609</td>\n",
+       "      <td>-0.98692</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>-5.02</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4533251</th>\n",
+       "      <td>10059249.0</td>\n",
+       "      <td>-0.29147</td>\n",
+       "      <td>-1.08484</td>\n",
+       "      <td>-0.98467</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>-5.05</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4533252</th>\n",
+       "      <td>10050536.0</td>\n",
+       "      <td>-0.29072</td>\n",
+       "      <td>-1.08484</td>\n",
+       "      <td>-0.98592</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>-4.70</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16911298</th>\n",
+       "      <td>29005409.0</td>\n",
+       "      <td>0.88867</td>\n",
+       "      <td>-1.36887</td>\n",
+       "      <td>0.87515</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>-10.02</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16911299</th>\n",
+       "      <td>28995730.0</td>\n",
+       "      <td>0.88837</td>\n",
+       "      <td>-1.36982</td>\n",
+       "      <td>0.87436</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>-9.86</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16911300</th>\n",
+       "      <td>29000568.0</td>\n",
+       "      <td>0.88841</td>\n",
+       "      <td>-1.36927</td>\n",
+       "      <td>0.87487</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>-9.36</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16911301</th>\n",
+       "      <td>28990874.0</td>\n",
+       "      <td>0.88763</td>\n",
+       "      <td>-1.37050</td>\n",
+       "      <td>0.87403</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>-9.51</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16911302</th>\n",
+       "      <td>29034342.0</td>\n",
+       "      <td>0.88910</td>\n",
+       "      <td>-1.36858</td>\n",
+       "      <td>0.87946</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>-12.96</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>8529526 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 pid        x        y        z   dev   refl  sel  sp\n",
+       "4532169    9880406.0 -0.26751 -1.06231 -0.99242   9.0  -4.64  1.0   1\n",
+       "4532171    9889137.0 -0.26801 -1.06406 -0.99267  10.0  -4.38  1.0   1\n",
+       "4533244   10050538.0 -0.29222 -1.08609 -0.98692   7.0  -5.02  1.0   1\n",
+       "4533251   10059249.0 -0.29147 -1.08484 -0.98467  10.0  -5.05  1.0   1\n",
+       "4533252   10050536.0 -0.29072 -1.08484 -0.98592  10.0  -4.70  1.0   1\n",
+       "...              ...      ...      ...      ...   ...    ...  ...  ..\n",
+       "16911298  29005409.0  0.88867 -1.36887  0.87515   4.0 -10.02  1.0   4\n",
+       "16911299  28995730.0  0.88837 -1.36982  0.87436   3.0  -9.86  1.0   4\n",
+       "16911300  29000568.0  0.88841 -1.36927  0.87487   5.0  -9.36  1.0   4\n",
+       "16911301  28990874.0  0.88763 -1.37050  0.87403   3.0  -9.51  1.0   4\n",
+       "16911302  29034342.0  0.88910 -1.36858  0.87946   3.0 -12.96  1.0   4\n",
+       "\n",
+       "[8529526 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## extract branch "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## filter "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qrdar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "path = '2021-06-28.Ove_W2-Fc(new).riproject/qrdar.csv'\n",
+    "translation = pd.read_csv(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>project name code</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2021-06-28.Ove_W2-Fc(new) Ove_W2_Fc 28</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        project name code\n",
+       "0  2021-06-28.Ove_W2-Fc(new) Ove_W2_Fc 28"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function __main__.<lambda>(row)>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ctag = lambda row: '{}-{}-{}'.format(*row[['plot', 'treetag', 'light']])\n",
+    "ctag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>project name code</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2021-06-28.Ove_W2-Fc(new) Ove_W2_Fc 28</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        project name code\n",
+       "0  2021-06-28.Ove_W2-Fc(new) Ove_W2_Fc 28"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translation.rename(columns={c:c.lower() for c in translation.columns}, inplace=True)\n",
+    "translation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "\"None of [Index(['plot', 'treetag', 'light'], dtype='object')] are in the [index]\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-10-52d7ef65809d>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mtranslation\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mloc\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'tag'\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtranslation\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mctag\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\frame.py\u001b[0m in \u001b[0;36mapply\u001b[1;34m(self, func, axis, raw, result_type, args, **kwds)\u001b[0m\n\u001b[0;32m   7546\u001b[0m             \u001b[0mkwds\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mkwds\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   7547\u001b[0m         )\n\u001b[1;32m-> 7548\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mop\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_result\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   7549\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   7550\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mapplymap\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m->\u001b[0m \u001b[1;34m\"DataFrame\"\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\apply.py\u001b[0m in \u001b[0;36mget_result\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    178\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply_raw\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    179\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 180\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply_standard\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    181\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    182\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mapply_empty_result\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\apply.py\u001b[0m in \u001b[0;36mapply_standard\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    269\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    270\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mapply_standard\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 271\u001b[1;33m         \u001b[0mresults\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mres_index\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply_series_generator\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    272\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    273\u001b[0m         \u001b[1;31m# wrap results\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\apply.py\u001b[0m in \u001b[0;36mapply_series_generator\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    298\u001b[0m                 \u001b[1;32mfor\u001b[0m \u001b[0mi\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mv\u001b[0m \u001b[1;32min\u001b[0m \u001b[0menumerate\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mseries_gen\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    299\u001b[0m                     \u001b[1;31m# ignore SettingWithCopy here in case the user mutates\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 300\u001b[1;33m                     \u001b[0mresults\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mi\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mf\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mv\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    301\u001b[0m                     \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresults\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mi\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mABCSeries\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    302\u001b[0m                         \u001b[1;31m# If we have a view on v, we need to make a copy because\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m<ipython-input-5-969063aaed20>\u001b[0m in \u001b[0;36m<lambda>\u001b[1;34m(row)\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mctag\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mlambda\u001b[0m \u001b[0mrow\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;34m'{}-{}-{}'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mrow\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'plot'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'treetag'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'light'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mctag\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\series.py\u001b[0m in \u001b[0;36m__getitem__\u001b[1;34m(self, key)\u001b[0m\n\u001b[0;32m    904\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_get_values\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    905\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 906\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_get_with\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    907\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    908\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_get_with\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\series.py\u001b[0m in \u001b[0;36m_get_with\u001b[1;34m(self, key)\u001b[0m\n\u001b[0;32m    944\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    945\u001b[0m         \u001b[1;31m# handle the dup indexing case GH#4246\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 946\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mloc\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    947\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    948\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_get_values_tuple\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m__getitem__\u001b[1;34m(self, key)\u001b[0m\n\u001b[0;32m    877\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    878\u001b[0m             \u001b[0mmaybe_callable\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcom\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply_if_callable\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 879\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_getitem_axis\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmaybe_callable\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    880\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    881\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_is_scalar_access\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mTuple\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_getitem_axis\u001b[1;34m(self, key, axis)\u001b[0m\n\u001b[0;32m   1097\u001b[0m                     \u001b[1;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Cannot index with multidimensional key\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1098\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1099\u001b[1;33m                 \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_getitem_iterable\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1100\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1101\u001b[0m             \u001b[1;31m# nested tuple slicing\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_getitem_iterable\u001b[1;34m(self, key, axis)\u001b[0m\n\u001b[0;32m   1035\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1036\u001b[0m         \u001b[1;31m# A collection of keys\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1037\u001b[1;33m         \u001b[0mkeyarr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mindexer\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_get_listlike_indexer\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mraise_missing\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1038\u001b[0m         return self.obj._reindex_with_indexers(\n\u001b[0;32m   1039\u001b[0m             \u001b[1;33m{\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;33m[\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mallow_dups\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_get_listlike_indexer\u001b[1;34m(self, key, axis, raise_missing)\u001b[0m\n\u001b[0;32m   1252\u001b[0m             \u001b[0mkeyarr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnew_indexer\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0max\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_reindex_non_unique\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1253\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1254\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_validate_read_indexer\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mraise_missing\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mraise_missing\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1255\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mkeyarr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1256\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Program\\Anaconda3\\envs\\treegraph\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_validate_read_indexer\u001b[1;34m(self, key, indexer, axis, raise_missing)\u001b[0m\n\u001b[0;32m   1296\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mmissing\u001b[0m \u001b[1;33m==\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mindexer\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1297\u001b[0m                 \u001b[0maxis_name\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_get_axis_name\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1298\u001b[1;33m                 \u001b[1;32mraise\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf\"None of [{key}] are in the [{axis_name}]\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1299\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1300\u001b[0m             \u001b[1;31m# We (temporarily) allow for some missing keys with .loc, except in\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mKeyError\u001b[0m: \"None of [Index(['plot', 'treetag', 'light'], dtype='object')] are in the [index]\""
+     ]
+    }
+   ],
+   "source": [
+    "translation.loc[:, 'tag'] = translation.apply(ctag, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "translation.tag = [t.replace('-nan', '') for t in translation.tag]\n",
+    "translation = translation[translation.project == project]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3.6",
+   "language": "python",
+   "name": "py3.6"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### ply_io.py

1. .ply exported from CloudCompare has "scalar_" in property names, so add a if statement to remove "scalar_" and get expected names.
2. If there is NAN values in any of the properties, read_ply() fails. So add a step to remove NAN values when read data from ply files.

### filter_branch.py

1. Currently, qrdar library reports some error when import it, so I change to import read_ply() and write_ply() from ply_io.py instead of qrdar.io
2. Add reflectance filtering [-20, 5] in case of RiEGL VZ400i records values down < -30dB.